### PR TITLE
Use `Anim(..)` instead of `Self(...)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ where
 
     /// Converts from `Anim<F>` to `Anim<&F>`.
     pub fn as_ref(&self) -> Anim<&F> {
-        Self(&self.0)
+        Anim(&self.0)
     }
 
     pub fn map_anim<W, G, A>(self, anim: A) -> Anim<impl Fun<T = F::T, V = W>>


### PR DESCRIPTION
Due to a compiler bug fixed by https://github.com/rust-lang/rust/pull/69340, this crate will stop compiling as discovered in https://crater-reports.s3.amazonaws.com/pr-69340/try%239ff4d07208097950831ed4ea9d76feb1eafc8baa/reg/pareen-0.2.1/log.txt. This PR fixes the problem for you.