### PR TITLE
Remove some sources of exponential slowdown of compile times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Version 0.2.6
+- Make exponential slowdown of compile times less likely
+
 ## Version 0.2.5
 - Add `Anim::repeat`, `Anim::hold` and `Anim::seq_continue`
 - Allow boxed animations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,7 +426,7 @@ where
     /// assert_approx_eq!(anim.eval(1.0f32), 0.0);
     /// ```
     pub fn backwards(self, end: F::T) -> Anim<impl Fun<T = F::T, V = F::V>> {
-        fun(move |t| self.eval(end - t))
+        (constant(end) - id()).map_anim(self)
     }
 }
 


### PR DESCRIPTION
For reference: https://github.com/rust-lang/rust/issues/72408

Some functions still contain nestable closures, but these are hopefully less frequent combinators.