### PR TITLE
Fix docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
-## Version 0.3.0 (unreleased)
+## Version 0.3.1 (2022-08-31)
+- Fix docs
+
+## Version 0.3.0 (2022-08-31)
 - Make operator overloading of `Mul`, `Add` and `Sub` more flexible.
   This may break compilation in some cases, since types are more generic now.
 - Add `AnimWithDur` for easier composition of animations that have a fixed duration

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ allocations are necessary. The downside to this is that it is diffcult to store
 pareen's animations. The recommended approach is to construct and evaluate
 animations on the fly.
 
-## Usage
-Just add this line to your dependencies in `Cargo.toml`:
-```
-pareen = "0.2"
-```
-
 ## Current Status
 I consider `pareen` to be an experimental approach, and I'm not sure if I'm
 still happy with it.  Anyway, the integration of easing functions could use


### PR DESCRIPTION
The usage instruction in the main readme was useless and prone to go out-of-date.