### PR TITLE
Add support for `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [".github"]
 default = ["std"]
 std = ["alloc", "num-traits/std"]
 alloc = []
+libm = ["num-traits/libm"]
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
@@ -26,4 +27,8 @@ assert_approx_eq = "1.0"
 gnuplot = "0.0.32"
 
 [package.metadata.docs.rs]
-features = ["std", "alloc", "easer"]
+features = ["std", "alloc", "libm", "easer"]
+
+[[example]]
+name = "plots"
+required-features = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,18 @@ keywords = ["animation", "combinators", "tween", "easing"]
 readme = "README.md"
 exclude = [".github"]
 
+[features]
+default = ["std"]
+std = ["alloc", "num-traits/std"]
+alloc = []
+
 [dependencies]
-num-traits = "0.2"
-easer = { version = "0.2", optional = true }
+num-traits = { version = "0.2", default-features = false }
+easer = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.0"
 gnuplot = "0.0.32"
 
 [package.metadata.docs.rs]
-features = ["easer"]
+features = ["std", "alloc", "easer"]

--- a/src/anim.rs
+++ b/src/anim.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Mul, RangeInclusive, Sub};
+use core::ops::{Add, Mul, RangeInclusive, Sub};
 
 use num_traits::{Float, Num, One, Zero};
 

--- a/src/anim.rs
+++ b/src/anim.rs
@@ -1,6 +1,8 @@
 use core::ops::{Add, Mul, RangeInclusive, Sub};
 
-use num_traits::{Float, Num, One, Zero};
+#[cfg(any(feature = "std", feature = "libm"))]
+use num_traits::Float;
+use num_traits::{float::FloatCore, Num, One, Zero};
 
 use crate::{constant, fun, id};
 
@@ -428,6 +430,7 @@ where
     }
 }
 
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<F> Anim<F>
 where
     F: Fun,
@@ -443,17 +446,23 @@ where
         self.map(Float::cos)
     }
 
-    /// Apply `Float::abs` to the animation values.
-    pub fn abs(self) -> Anim<impl Fun<T = F::T, V = F::V>> {
-        self.map(Float::abs)
-    }
-
     /// Apply `Float::powf` to the animation values.
     pub fn powf(self, e: F::V) -> Anim<impl Fun<T = F::T, V = F::V>> {
         self.map(move |v| v.powf(e))
     }
+}
 
-    /// Apply `Float::powi` to the animation values.
+impl<F> Anim<F>
+where
+    F: Fun,
+    F::V: FloatCore,
+{
+    /// Apply `FloatCore::abs` to the animation values.
+    pub fn abs(self) -> Anim<impl Fun<T = F::T, V = F::V>> {
+        self.map(FloatCore::abs)
+    }
+
+    /// Apply `FloatCore::powi` to the animation values.
     pub fn powi(self, n: i32) -> Anim<impl Fun<T = F::T, V = F::V>> {
         self.map(move |v| v.powi(n))
     }
@@ -462,7 +471,7 @@ where
 impl<F> Anim<F>
 where
     F: Fun,
-    F::T: Copy + Float,
+    F::T: Copy + FloatCore,
 {
     /// Transform an animation in time, so that its time `[0 .. 1]` is shifted
     /// and scaled into the given `range`.
@@ -572,13 +581,14 @@ where
     /// assert_approx_eq!(anim.eval(1.0), 10.0);
     /// assert_approx_eq!(anim.eval(2.0), 15.0);
     /// ```
-    ///
-    /// It is also possible to linearly interpolate between two non-constant
-    /// animations:
-    /// ```
-    /// let anim = pareen::circle().sin().lerp(pareen::circle().cos());
-    /// let value: f32 = anim.eval(0.5f32);
-    /// ```
+    #[cfg_attr(any(feature = "std", feature = "libm"), doc = r##"
+It is also possible to linearly interpolate between two non-constant
+animations:
+```
+let anim = pareen::circle().sin().lerp(pareen::circle().cos());
+let value: f32 = anim.eval(0.5f32);
+```
+    "##)]
     pub fn lerp<G, A>(self, other: A) -> Anim<impl Fun<T = F::T, V = F::V>>
     where
         G: Fun<T = F::T, V = F::V>,

--- a/src/anim_box.rs
+++ b/src/anim_box.rs
@@ -1,4 +1,6 @@
-use std::ops::{Deref, Sub};
+use core::ops::{Deref, Sub};
+extern crate alloc;
+use alloc::boxed::Box;
 
 use crate::{Anim, Fun};
 

--- a/src/anim_with_dur.rs
+++ b/src/anim_with_dur.rs
@@ -1,6 +1,6 @@
 use core::ops::{Add, Div, Mul, Sub};
 
-use num_traits::{Float, One};
+use num_traits::{float::FloatCore, One};
 
 use crate::{Anim, Fun};
 
@@ -59,7 +59,7 @@ where
 impl<F> Anim<F>
 where
     F: Fun,
-    F::T: Clone + Float,
+    F::T: Clone + FloatCore,
 {
     pub fn scale_to_dur(self, dur: F::T) -> AnimWithDur<impl Fun<T = F::T, V = F::V>> {
         self.scale_time(F::T::one() / dur).dur(dur)
@@ -147,7 +147,7 @@ where
 impl<F> AnimWithDur<F>
 where
     F: Fun,
-    F::T: Clone + Float,
+    F::T: Clone + FloatCore,
 {
     pub fn repeat(self) -> Anim<impl Fun<T = F::T, V = F::V>> {
         self.0.repeat(self.1)

--- a/src/anim_with_dur.rs
+++ b/src/anim_with_dur.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use core::ops::{Add, Div, Mul, Sub};
 
 use num_traits::{Float, One};
 

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Mul, Neg, Sub};
+use core::ops::{Add, Mul, Neg, Sub};
 
 use crate::{primitives::ConstantClosure, Anim, Fun};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,10 @@
 //! assert_approx_eq!(value, 0.0);
 //! ```
 
+#![no_std]
+
 mod anim;
+#[cfg(feature = "alloc")]
 mod anim_box;
 mod anim_with_dur;
 mod arithmetic;
@@ -48,6 +51,7 @@ pub mod stats;
 mod easer_combinators;
 
 pub use anim::{cond, lerp, Anim, Fun};
+#[cfg(feature = "alloc")]
 pub use anim_box::AnimBox;
 pub use anim_with_dur::{slice, AnimWithDur};
 pub use primitives::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,17 +23,19 @@
 //! // Animations can be played in sequence
 //! let anim2 = anim1.seq(0.7, pareen::prop(0.25) + 0.5);
 //!
-//! // Animations can be composed and transformed in various ways
-//! let anim3 = anim2
-//!     .lerp(pareen::circle().cos())
-//!     .scale_min_max(5.0, 10.0)
-//!     .backwards(1.0)
-//!     .squeeze(0.5..=1.0);
-//!
-//! let anim4 = pareen::cubic(&[1.0, 2.0, 3.0, 4.0]) - anim3;
-//!
-//! let value = anim4.eval(1.0);
-//! assert_approx_eq!(value, 0.0);
+#![cfg_attr(any(feature = "std", feature = "libm"), doc = r##"
+// Animations can be composed and transformed in various ways
+let anim3 = anim2
+    .lerp(pareen::circle().cos())
+    .scale_min_max(5.0, 10.0)
+    .backwards(1.0)
+    .squeeze(0.5..=1.0);
+
+    let anim4 = pareen::cubic(&[1.0, 2.0, 3.0, 4.0]) - anim3;
+
+    let value = anim4.eval(1.0);
+    assert_approx_eq!(value, 0.0);
+"##)]
 //! ```
 
 #![no_std]
@@ -47,7 +49,7 @@ mod primitives;
 
 pub mod stats;
 
-#[cfg(feature = "easer")]
+#[cfg(all(feature = "easer", any(feature = "std", feature = "libm")))]
 mod easer_combinators;
 
 pub use anim::{cond, lerp, Anim, Fun};
@@ -59,8 +61,8 @@ pub use primitives::{
 };
 pub use stats::{simple_linear_regression, simple_linear_regression_with_slope};
 
-#[cfg(feature = "easer")]
+#[cfg(all(feature = "easer", any(feature = "std", feature = "libm")))]
 pub use easer;
 
-#[cfg(feature = "easer")]
+#[cfg(all(feature = "easer", any(feature = "std", feature = "libm")))]
 pub use easer_combinators::{ease_in, ease_in_out, ease_out};

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,5 +1,5 @@
-use std::marker::PhantomData;
-use std::ops::Mul;
+use core::marker::PhantomData;
+use core::ops::Mul;
 
 use crate::{Anim, Fun};
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -3,7 +3,7 @@ use core::ops::Mul;
 
 use crate::{Anim, Fun};
 
-use num_traits::{Float, FloatConst};
+use num_traits::{FloatConst, float::FloatCore};
 
 /// Turn any function `Fn(T) -> V` into an [`Anim`](struct.Anim.html).
 ///
@@ -143,8 +143,8 @@ where
 /// Proportionally increase value from zero to 2π.
 pub fn circle<T, V>() -> Anim<impl Fun<T = T, V = V>>
 where
-    T: Float,
-    V: Float + FloatConst + From<T>,
+    T: FloatCore,
+    V: FloatCore + FloatConst + From<T>,
 {
     prop(V::PI() * (V::one() + V::one()))
 }
@@ -152,8 +152,8 @@ where
 /// Proportionally increase value from zero to π.
 pub fn half_circle<T, V>() -> Anim<impl Fun<T = T, V = V>>
 where
-    T: Float,
-    V: Float + FloatConst + From<T>,
+    T: FloatCore,
+    V: FloatCore + FloatConst + From<T>,
 {
     prop(V::PI())
 }
@@ -161,8 +161,8 @@ where
 /// Proportionally increase value from zero to π/2.
 pub fn quarter_circle<T, V>() -> Anim<impl Fun<T = T, V = V>>
 where
-    T: Float,
-    V: Float + FloatConst + From<T>,
+    T: FloatCore,
+    V: FloatCore + FloatConst + From<T>,
 {
     prop(V::PI() * (V::one() / (V::one() + V::one())))
 }
@@ -170,7 +170,7 @@ where
 /// Evaluate a quadratic polynomial in time.
 pub fn quadratic<T>(w: &[T; 3]) -> Anim<impl Fun<T = T, V = T> + '_>
 where
-    T: Float,
+    T: FloatCore,
 {
     fun(move |t| {
         let t2 = t * t;
@@ -182,7 +182,7 @@ where
 /// Evaluate a cubic polynomial in time.
 pub fn cubic<T>(w: &[T; 4]) -> Anim<impl Fun<T = T, V = T> + '_>
 where
-    T: Float,
+    T: FloatCore,
 {
     fun(move |t| {
         let t2 = t * t;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul};
+use core::ops::{Add, Div, Mul};
 
 use num_traits::{AsPrimitive, Float, Zero};
 
@@ -105,9 +105,11 @@ where
     Anim(Line { y_intercept, slope })
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "alloc"))]
 mod tests {
     use assert_approx_eq::assert_approx_eq;
+    extern crate alloc;
+    use alloc::vec;
 
     use super::simple_linear_regression;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,6 +1,6 @@
 use core::ops::{Add, Div, Mul};
 
-use num_traits::{AsPrimitive, Float, Zero};
+use num_traits::{float::FloatCore, AsPrimitive, Zero};
 
 use crate::{Anim, AnimWithDur, Fun};
 
@@ -65,7 +65,7 @@ where
 
 pub fn simple_linear_regression_with_slope<V, F, A>(slope: V, values: A) -> Anim<Line<V>>
 where
-    V: 'static + Float + Copy,
+    V: 'static + FloatCore + Copy,
     F: Fun<T = usize, V = (V, V)>,
     A: Into<AnimWithDur<F>>,
     usize: AsPrimitive<V>,
@@ -83,7 +83,7 @@ where
 
 pub fn simple_linear_regression<V, F, A>(values: A) -> Anim<Line<V>>
 where
-    V: 'static + Float + Copy,
+    V: 'static + FloatCore + Copy,
     F: Fun<T = usize, V = (V, V)>,
     A: Into<AnimWithDur<F>>,
     usize: AsPrimitive<V>,


### PR DESCRIPTION
This allows pareen to be used in embedded environments without `std`, which entails:

- Switching from `std::` to `core::` for basic traits/etc.
- Gating usage of `Box` behind an `alloc` feature.
- Switching from `num_traits::Float` to `num_traits::float::FloatCore`.
- Gating usage of `sin` and friends behind `std` or `libm` features.

I checked all combinations of features and the tests (that still make sense) all pass.